### PR TITLE
Update frontend env handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ npm run dev
 - `DEEPSEEK_API_KEY`: DeepSeek API 密鑰
 - `MODEL_NAME`: LLM 模型名稱
 - `EMBEDDING_MODEL`: 嵌入模型名稱
+- `NEXT_PUBLIC_API_URL`: 前端連接的 API 位址，預設為 `http://localhost:8000`
 
 ## 文檔上傳
 

--- a/run_all.py
+++ b/run_all.py
@@ -174,7 +174,7 @@ def run_frontend():
     print(f"{Colors.BLUE}[前端] 啟動 Next.js 應用...{Colors.ENDC}")
     
     env = os.environ.copy()
-    env["NEXT_PUBLIC_API_URL"] = "http://localhost:8000"
+    env["NEXT_PUBLIC_API_URL"] = os.environ.get("NEXT_PUBLIC_API_URL", "http://localhost:8000")
     
     frontend_process = subprocess.Popen(
         ["npm", "run", "dev"],

--- a/run_frontend_only.bat
+++ b/run_frontend_only.bat
@@ -11,8 +11,10 @@ if not exist "node_modules" (
     call npm install --legacy-peer-deps
 )
 
-:: 設定環境變數
-set NEXT_PUBLIC_API_URL=http://localhost:8000
+:: 設定環境變數，可由外部覆蓋
+if not defined NEXT_PUBLIC_API_URL (
+    set NEXT_PUBLIC_API_URL=http://localhost:8000
+)
 
 :: 啟動前端
 echo [前端] 啟動前端服務...

--- a/run_frontend_only.sh
+++ b/run_frontend_only.sh
@@ -16,8 +16,8 @@ if [ ! -d "node_modules" ]; then
     npm install --legacy-peer-deps
 fi
 
-# 設定環境變數
-export NEXT_PUBLIC_API_URL=http://localhost:8000
+# 設定環境變數，可由外部覆蓋
+export NEXT_PUBLIC_API_URL="${NEXT_PUBLIC_API_URL:-http://localhost:8000}"
 
 # 啟動前端
 echo -e "${GREEN}[前端] 啟動前端服務...${NC}"


### PR DESCRIPTION
## Summary
- allow overriding NEXT_PUBLIC_API_URL in scripts
- document NEXT_PUBLIC_API_URL setup in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685676905c18832cbbcf459b745ce16b